### PR TITLE
Feat/chapter6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,34 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// QueryDSL : OpenFeign
+	implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+	implementation "io.github.openfeign.querydsl:querydsl-core:7.0"
+	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// QueryDSL 관련 설정
+// generated/querydsl 폴더 생성 & 삽입
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// 소스 세트에 생성 경로 추가 (구체적인 경로 지정)
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+// 컴파일 시 생성 경로 지정
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+// clean 태스크에 생성 폴더 삭제 로직 추가
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/umc9th/Umc9thApplication.java
+++ b/src/main/java/com/example/umc9th/Umc9thApplication.java
@@ -4,8 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableWebMvc
 public class Umc9thApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/umc9th/config/QueryDslConfig.java
+++ b/src/main/java/com/example/umc9th/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.umc9th.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/umc9th/config/SwaggerConfig.java
+++ b/src/main/java/com/example/umc9th/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.example.umc9th.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Umc 9th API")
+                .description("Umc 9th API 명세서")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
@@ -1,0 +1,41 @@
+package com.example.umc9th.domain.review.controller;
+
+import com.example.umc9th.domain.review.dto.ReviewResponseDto;
+import com.example.umc9th.domain.review.service.ReviewService;
+import com.example.umc9th.global.dto.CursorResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+@Tag(name = "리뷰")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(
+            summary = "리뷰 조회",
+            description = "가게별, 별점별로 리뷰를 조회합니다.")
+    @GetMapping
+    public CursorResponseDto<ReviewResponseDto.Review> getReviews(
+            @RequestParam(required = false) String storeName,
+            @RequestParam(required = false, defaultValue = "0.0") Float minStar,
+            @RequestParam(required = false, defaultValue = "5.0") Float maxStar,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "10") Integer size) {
+
+        return reviewService.getReviews(storeName,
+                minStar,
+                maxStar,
+                cursorId,
+                size);
+    }
+
+}

--- a/src/main/java/com/example/umc9th/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/example/umc9th/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.umc9th.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class ReviewResponseDto {
+    // 객체 생성 방지
+    private ReviewResponseDto() {}
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Review{
+        private Long id;
+        private String nickname;
+        private Float star;
+        private String content;
+        private String createdAt;
+        private List<String> reviewImages;
+
+        private String reviewReplyContent;
+        private String reviewReplyCreatedAt;
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc9th/domain/review/entity/Review.java
@@ -5,6 +5,8 @@ import com.example.umc9th.domain.store.entity.Store;
 import com.example.umc9th.domain.user.entity.User;
 import com.example.umc9th.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -35,6 +37,11 @@ public class Review extends BaseEntity {
 
     @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    @Min(value = 0, message = "별점은 0점 이상이어야 합니다.")
+    @Max(value = 5, message = "별점은 5점을 초과할 수 없습니다.")
+    private Float star;
 
     @OneToMany(mappedBy = "review", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewPredicate.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewPredicate.java
@@ -1,0 +1,32 @@
+package com.example.umc9th.domain.review.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.util.StringUtils;
+
+import static com.example.umc9th.domain.review.entity.QReview.review;
+import static com.example.umc9th.domain.store.entity.QStore.store;
+
+public class ReviewPredicate {
+
+    private ReviewPredicate() {}
+
+    public static BooleanExpression storeNameContains(String storeName) {
+        return StringUtils.hasText(storeName) ? store.name.contains(storeName) : null;
+    }
+
+    public static BooleanExpression starRange(Float minStar, Float maxStar) {
+        if (minStar != null && maxStar != null) {
+            return review.star.between(minStar, maxStar);
+        } else if (minStar != null) {
+            return review.star.goe(minStar); // goe: great or equal
+        } else if (maxStar != null) {
+            return review.star.loe(maxStar); // loe: low or equal
+        }
+
+        return null;
+    }
+
+    public static BooleanExpression userIdEquals(Long userId) {
+        return userId != null ? review.user.id.eq(userId) : null;
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewQueryDsl.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewQueryDsl.java
@@ -1,0 +1,13 @@
+package com.example.umc9th.domain.review.repository;
+
+import com.example.umc9th.domain.review.dto.ReviewResponseDto;
+import com.querydsl.core.types.Predicate;
+import org.springframework.data.domain.Slice;
+
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewQueryDsl {
+    Slice<ReviewResponseDto.Review> getReviews(Predicate predicate,
+                                               Long cursorId,
+                                               Pageable pageable);
+}

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
     @Modifying
     @Query("DELETE FROM Review r WHERE r.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.example.umc9th.domain.review.repository;
+
+import com.example.umc9th.domain.review.dto.ReviewResponseDto;
+import com.example.umc9th.domain.review.entity.QReviewImage;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.umc9th.domain.review.entity.QReview.review;
+import static com.example.umc9th.domain.store.entity.QStore.store;
+import static com.example.umc9th.domain.user.entity.QUser.user;
+import static com.example.umc9th.domain.review.entity.QReviewImage.reviewImage;
+import static com.example.umc9th.domain.review.entity.QReviewReply.reviewReply;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<ReviewResponseDto.Review> getReviews(Predicate predicate,
+                                                      Long cursorId,
+                                                      Pageable pageable) {
+
+        BooleanBuilder builder = new BooleanBuilder(predicate);
+
+        // 커서가 있으면
+        if (cursorId != null) {
+            builder.and(review.id.lt(cursorId)); // lt: less than
+        }
+
+        // 'size + 1' 만큼 조회 (다음 페이지 유무 확인용)
+        int pageSize = pageable.getPageSize();
+
+        List<ReviewResponseDto.Review> content = queryFactory
+                .from(review)
+                .leftJoin(review.user, user)
+                .leftJoin(review.reviewImages, reviewImage)
+                .leftJoin(review.reviewReply, reviewReply)
+                .where(builder)
+                .orderBy(review.id.desc())
+                .limit(pageSize + 1)
+                .transform( // transform은 자바 애플리케이션 메모리에서 sql 결과 리스트를 가공
+                        GroupBy.groupBy(review.id).list(
+                                Projections.constructor(ReviewResponseDto.Review.class,
+                                        review.id,
+                                        user.nickname,
+                                        review.star,
+                                        review.content,
+                                        review.createdAt.stringValue(),
+                                        GroupBy.list(reviewImage.imageUrl),
+                                        reviewReply.content,
+                                        reviewReply.createdAt.stringValue()
+                                )
+                        )
+                );
+
+        // hasNext (다음 페이지 존재 여부) 확인
+        boolean hasNext = false;
+        if (content.size() > pageSize) {
+            content.remove(pageSize);
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc9th/domain/review/service/ReviewService.java
@@ -1,5 +1,14 @@
 package com.example.umc9th.domain.review.service;
 
+import com.example.umc9th.domain.review.dto.ReviewResponseDto;
+import com.example.umc9th.global.dto.CursorResponseDto;
+
 public interface ReviewService {
     void createReview(String content, Long userId, Long storeId);
+
+    CursorResponseDto<ReviewResponseDto.Review> getReviews(String storeName,
+                                                           Float minStar,
+                                                           Float maxStar,
+                                                           Long cursorId,
+                                                           int size);
 }

--- a/src/main/java/com/example/umc9th/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/umc9th/domain/review/service/ReviewServiceImpl.java
@@ -1,13 +1,25 @@
 package com.example.umc9th.domain.review.service;
 
+import com.example.umc9th.domain.review.dto.ReviewResponseDto;
 import com.example.umc9th.domain.review.entity.Review;
+import com.example.umc9th.domain.review.repository.ReviewPredicate;
+import com.example.umc9th.domain.review.repository.ReviewQueryDsl;
 import com.example.umc9th.domain.review.repository.ReviewRepository;
 import com.example.umc9th.domain.store.repository.StoreRepository;
 import com.example.umc9th.domain.user.repository.UserRepository;
+import com.example.umc9th.global.dto.CursorResponseDto;
+import com.querydsl.core.BooleanBuilder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -27,4 +39,40 @@ public class ReviewServiceImpl implements ReviewService{
 
         reviewRepository.save(review);
     }
+
+    @Override
+    public CursorResponseDto<ReviewResponseDto.Review> getReviews(String storeName,
+                                                                  Float minStar,
+                                                                  Float maxStar,
+                                                                  Long cursorId,
+                                                                  int size) {
+        // 1. 서비스에서 Predicate 조합
+        BooleanBuilder predicate = new BooleanBuilder();
+        predicate.and(ReviewPredicate.userIdEquals(1L));// todo: 로그인한 사용자
+        predicate.and(ReviewPredicate.storeNameContains(storeName));
+        predicate.and(ReviewPredicate.starRange(minStar, maxStar));
+
+        // 2. Pageable 객체 생성
+        Pageable pageable = PageRequest.of(0, size); // 커서 기반이므로 page는 0
+
+        Slice<ReviewResponseDto.Review> slice = reviewRepository.getReviews(
+                predicate,
+                cursorId,
+                pageable
+        );
+
+        // nextCursor 계산
+        String nextCursor = null;
+        if (slice.hasNext()) {
+            List<ReviewResponseDto.Review> content = slice.getContent();
+            if (!content.isEmpty()) {
+                nextCursor = content.get(content.size() - 1).getId().toString();
+            }
+        }
+
+        // 5. CursorResponseDto 반환
+        return new CursorResponseDto<>(slice, nextCursor);
+    }
+
+
 }

--- a/src/main/java/com/example/umc9th/global/dto/CursorResponseDto.java
+++ b/src/main/java/com/example/umc9th/global/dto/CursorResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.umc9th.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springframework.data.domain.Slice; // import 확인
+
+import java.util.List;
+
+@Getter
+public class CursorResponseDto<T> {
+
+    @Schema(description = "데이터 리스트")
+    private List<T> content;
+
+    @Schema(description = "현재 페이지의 데이터 개수", example = "10")
+    private int pageSize;
+
+    @Schema(description = "다음 페이지를 위한 커서 값 (응답의 마지막 아이템의 식별자)", example = "123")
+    private String nextCursor;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private boolean hasNext;
+
+    public CursorResponseDto(Slice<T> slice, String nextCursor) {
+        this.content = slice.getContent();
+        this.pageSize = slice.getNumberOfElements();
+        this.nextCursor = nextCursor;
+        this.hasNext = slice.hasNext();
+    }
+}

--- a/src/main/java/com/example/umc9th/global/dto/PageResponseDto.java
+++ b/src/main/java/com/example/umc9th/global/dto/PageResponseDto.java
@@ -1,0 +1,38 @@
+package com.example.umc9th.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponseDto<T> { // 제네릭 타입으로 다른 리스트에도 재사용 가능
+
+    @Schema(description = "데이터 리스트")
+    private List<T> content;
+
+    @Schema(description = "현재 페이지 번호", example = "0")
+    private int pageNumber;
+
+    @Schema(description = "페이지 크기", example = "10")
+    private int pageSize;
+
+    @Schema(description = "전체 페이지 수", example = "15")
+    private int totalPages;
+
+    @Schema(description = "전체 요소 개수", example = "145")
+    private long totalElements;
+
+    @Schema(description = "마지막 페이지 여부", example = "false")
+    private boolean last;
+
+    public PageResponseDto(Page<T> page) {
+        this.content = page.getContent();
+        this.pageNumber = page.getNumber()+1; // 0-based
+        this.pageSize = page.getSize();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.last = page.isLast();
+    }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용

> 내가 작성한 리뷰 조회 api 구현(가게 이름, 별점으로 필터링 가능, 커서 기반 페이징)
<img width="526" height="456" alt="image" src="https://github.com/user-attachments/assets/0b1a43e9-959e-47c5-a5e0-a439b8b683dc" />
: 내가 작성한 리뷰
<img width="558" height="906" alt="image" src="https://github.com/user-attachments/assets/469b65a5-29f6-4726-9aa5-5c2f6345eba4" />
: 커서 기반 페이징
<img width="554" height="920" alt="image" src="https://github.com/user-attachments/assets/bae8db65-ce0f-43da-a2f3-e4584d3f82d7" />
: 별점 필터링



## 🧐 리뷰 포인트
<img width="586" height="738" alt="image" src="https://github.com/user-attachments/assets/1851cc54-9746-46ed-8d59-c189e07b7178" />

> 워크북에서 QueryDsl 인터페이스 만들고 서비스로 구현했던데 저게 무슨 의도인지 모르겠습니다..



---

> `close #4 `
